### PR TITLE
Update BaseViewController 

### DIFF
--- a/DribbbleReader/BaseViewController.swift
+++ b/DribbbleReader/BaseViewController.swift
@@ -28,7 +28,6 @@ class BaseViewController: UIViewController {
         let popularShot = ShotCollectionViewController(nibName: "ShotCollectionViewController", bundle: nil)
         popularShot.title = "Popular"
         popularShot.API_URL = Config.POPULAR_URL
-        popularShot.parentNavigationController = self.navigationController!
         popularShot.loadShots()
         controllerArray.append(popularShot)
         


### PR DESCRIPTION
With commit https://github.com/naoyashiga/Dunk/commit/af99461c453f990ce0fac715b8d39cb6392f9757, we no longer need to set the `parentNavigationController` for `ShotCollectionViewController` in `BaseViewController`. This PR addresses a compile issue with the last round of changes.
